### PR TITLE
fix: fix option value parsing

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -6,7 +6,7 @@ function parseOption<T>(value: T | boolean | undefined, defaultValue?: T) {
     return value
 
   if (value === true)
-    return defaultValue ?? {}
+    return defaultValue ?? {} as T
 
   if (value)
     return { ...defaultValue, ...value }

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,14 +1,17 @@
 import { isH5, isMp } from '@uni-helper/uni-env'
 import type { ResolvedUniPresetOptions, UniPresetOptions } from './types'
 
-function convertToObject<T>(value: T | boolean | undefined, defaultValue?: T) {
+function parseOption<T>(value: T | boolean | undefined, defaultValue?: T) {
+  if (value === false)
+    return value
+
   if (value === true)
     return defaultValue ?? {}
 
-  else if (value)
+  if (value)
     return { ...defaultValue, ...value }
 
-  else if (defaultValue)
+  if (defaultValue)
     return defaultValue
 
   return false
@@ -16,9 +19,15 @@ function convertToObject<T>(value: T | boolean | undefined, defaultValue?: T) {
 
 export function resolveOptions(userOptions: Partial<UniPresetOptions> = {}): ResolvedUniPresetOptions {
   const dark = isH5 ? 'class' : 'media'
-  const uno = convertToObject(userOptions.uno, { dark })
-  const attributify = convertToObject(userOptions.attributify, { ignoreAttributes: isH5 ? undefined : ['block', 'fixed'] })
-  const remRpx = convertToObject(userOptions.remRpx, { mode: isMp ? undefined : 'rpx2rem' })
+  const uno = parseOption(userOptions.uno, { dark })
+  const attributify = parseOption(
+    userOptions.attributify,
+    { ignoreAttributes: isH5 ? undefined : ['block', 'fixed'] },
+  )
+  const remRpx = parseOption(
+    userOptions.remRpx,
+    { mode: isMp ? undefined : 'rpx2rem' },
+  )
 
   return {
     ...userOptions,


### PR DESCRIPTION
<!--

DO NOT INGORE THE TEMPLATE!
请不要忽视这个模板！

Thank you for contributing!
感谢你的贡献！

Before submitting the PR, please make sure you do the following:
在提交PR之前，请确保你做到以下几点：

- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.
- 检查是否已经有一个以同样方式解决该问题的 PR，以避免重复创建。
- 在这个 PR 中描述 **PR 所要解决的问题**，或者引用它所解决的问题（例如 `fixes #123`）。
- 理想情况下，提交没有这个 PR 的情况下失败但在有 PR 的情况下通过的相关测试。

-->

### Description 描述

<!--

Please insert your description here and provide especially info about the "what" this PR is solving
请在此插入你的描述，并提供有关该 PR 所解决的 **问题** 的信息。

-->

部分修复 https://github.com/uni-helper/unocss-preset-uni/issues/8

1. convertToObject 不太准确，最后不一定返回一个 object，调整方法名为 parseOption
2. 移除多余的 else
3. 如果 value 是 false，直接返回，避免进入原本的 else if (defaultValue) 分支

### Linked Issues 关联的 Issues


### Additional context 额外上下文

<!--

e.g. is there anything you'd like reviewers to focus on?
例如，有什么东西是你希望审查人关注的？

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the handling of `false` values in options parsing to enhance configuration flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->