### PR TITLE
type: fix wrong type

### DIFF
--- a/src/presetUni.ts
+++ b/src/presetUni.ts
@@ -1,4 +1,4 @@
-import type { Preset } from 'unocss'
+import type { PresetFactory } from 'unocss'
 import { definePreset } from 'unocss'
 import { resolveOptions } from './options'
 import { createPresets } from './presets'
@@ -11,7 +11,7 @@ export type { Theme } from '@unocss/preset-mini'
 
 export { createPresets, createTransformers, createVariants, resolveOptions, theme }
 
-export const presetUni = definePreset((userOptions: UserUniPresetOptions = {}) => {
+export const presetUni: PresetFactory<object, UserUniPresetOptions> = definePreset((userOptions = {}) => {
   const options = resolveOptions(userOptions)
   const presets = createPresets(options)
   const variants = createVariants()
@@ -28,5 +28,5 @@ export const presetUni = definePreset((userOptions: UserUniPresetOptions = {}) =
       else
         config.transformers = [...config.transformers, ...transformers]
     },
-  } as Preset<object>
+  }
 })


### PR DESCRIPTION
### Description 描述

打包后无法从unocss包识别出PresetFactory

具体原因目前找不到，若 definePreset 从 @unocss/core 提取将不会产生该问题

### Linked Issues 关联的 Issues

fix #28 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved type safety and clarity for the `presetUni` export, enhancing user experience with more reliable presets.
  
- **Bug Fixes**
	- Adjusted function signatures to reduce potential type-related errors, ensuring smoother functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->