### PR TITLE
fix(deps): peerDependencies are not automatically installed for npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,10 +53,6 @@
     "postinstall": "node scripts/apply-patch.mjs"
   },
   "peerDependencies": {
-    "@unocss/preset-legacy-compat": ">=0.58",
-    "@unocss/preset-mini": ">=0.58",
-    "@unocss/rule-utils": ">=0.58",
-    "@unocss/vite": ">=0.58",
     "unocss": ">=0.58",
     "unocss-applet": ">=0.7"
   },
@@ -69,15 +65,15 @@
     }
   },
   "dependencies": {
-    "@uni-helper/uni-env": "^0.1.7"
+    "@uni-helper/uni-env": "^0.1.7",
+    "@unocss/preset-legacy-compat": ">=0.58",
+    "@unocss/preset-mini": ">=0.58",
+    "@unocss/rule-utils": ">=0.58",
+    "@unocss/vite": ">=0.58"
   },
   "devDependencies": {
     "@types/node": "^20.17.12",
     "@uni-helper/eslint-config": "^0.2.2",
-    "@unocss/preset-legacy-compat": "^0.65.4",
-    "@unocss/preset-mini": "^0.65.4",
-    "@unocss/rule-utils": "^0.65.4",
-    "@unocss/vite": "^0.65.4",
     "bumpp": "^9.10.0",
     "eslint": "^9.18.0",
     "esno": "^4.8.0",


### PR DESCRIPTION
<!--

DO NOT INGORE THE TEMPLATE!
请不要忽视这个模板！

Before submitting the PR, please make sure you do the following:
在提交 PR 之前，请确保你做到以下几点：

- Read the [Contributing Guide](https://github.com/antfu/contribute) and [Notes from a tired maintainer](https://github.com/pi0/tired-maintainer).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.
- 阅读 [贡献指南](https://github.com/antfu/contribute) 和 [一位疲惫的维护者的笔记](https://github.com/ModyQyW/tired-maintainer)。
- 检查是否已经有一个以同样方式解决该问题的 PR，以避免重复创建。
- 在这个 PR 中描述 **PR 所要解决的问题**，或者引用它所解决的问题（例如 `fixes #123`）。
- 理想情况下，提交没有这个 PR 的情况下失败但在有 PR 的情况下通过的相关测试。

-->

### Description 描述

<!--

Please insert your description here and provide especially info about the "what" this PR is solving
请在此插入你的描述，并提供有关该 PR 所解决的 **问题** 的信息。

-->

按照文档来说，只要求用户安装了 `unocss` 和 `unocss-applet` 这两个依赖，所以除了两个库在 `peerDependencies` 中外，其他依赖应该移到 `dependencies`.

### Linked Issues 关联的 Issues
https://github.com/uni-helper/create-uni/issues/110
### Additional context 额外上下文

<!--

e.g. is there anything you'd like reviewers to focus on?
例如，有什么东西是你希望审查人关注的？

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated dependency management to move several Unocss-related packages from peer and dev dependencies to main dependencies. No impact on user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->